### PR TITLE
Incorrect Server listing gamemode name

### DIFF
--- a/gamemode/sh_init.lua
+++ b/gamemode/sh_init.lua
@@ -6,7 +6,6 @@ GM.Email = "N/A"
 GM.Website = "N/A"
 
 function GM:Initialize()
-
 end 
 
 -- Global Functions


### PR DESCRIPTION
When hosting this gamemode on a server, the gamemode name is shown incorrectly as "Base Gamemode". The gamemode has to be initialized properly as advised in the Gmod Wiki.
