### PR TITLE
Found a misspelled word: ALIGN of TEXT_ALIGN_BOTTOM of label.lua

### DIFF
--- a/gamemode/sgui/label.lua
+++ b/gamemode/sgui/label.lua
@@ -27,7 +27,7 @@ if CLIENT then
 
         if self.AlignY == TEXT_ALIGN_CENTER then
             y = y + (self:GetHeight() - h) / 2
-        elseif self.AlignY == TEXT_ALIGH_BOTTOM then
+        elseif self.AlignY == TEXT_ALIGN_BOTTOM then
             y = y + self:GetHeight() - h
         end
 


### PR DESCRIPTION
Is this due to earlier mistakes or did I just bring this to your attention.
