### PR TITLE
Doesnt scramble initial overide sequence

### DIFF
--- a/entities/entities/info_ff_screen/shared.lua
+++ b/entities/entities/info_ff_screen/shared.lua
@@ -109,7 +109,7 @@ if SERVER then
         self:SetNWEntity("user", nil)
 
         self:GenerateOverrideSequence()
-        self:ShuffleCurrentOverrideSequence()
+        --self:ShuffleCurrentOverrideSequence()
 
         self.FreeGUIIDs = {}
 


### PR DESCRIPTION
This would alleviate some of issue #48, making initial ship access easier. 
I know that this plan has been changed. But maybe we should keep it usable until its replacement is ready.
